### PR TITLE
Исправление примера с ошибкой 

### DIFF
--- a/1-js/06-advanced-functions/01-recursion/article.md
+++ b/1-js/06-advanced-functions/01-recursion/article.md
@@ -460,7 +460,7 @@ list.next.next.next = { value: 4 };
 
 ```js
 let secondList = list.next.next;
-list.next.next = null;
+secondList.next.next = null;
 ```
 
 ![разделение связанного списка](linked-list-split.svg)


### PR DESCRIPTION
Ошибка в примере разделения связанного списка на несколько частей.
Вместо вызова ```secondList.next.next = null;``` был использован следующий вызов ```list.next.next = null;```