### PR TITLE
fix example with deleteProperty

### DIFF
--- a/1-js/99-js-misc/01-proxy/article.md
+++ b/1-js/99-js-misc/01-proxy/article.md
@@ -361,9 +361,10 @@ user = new Proxy(user, {
 */!*
     if (prop.startsWith('_')) {
       throw new Error("Отказано в доступе");
+    } else {
+      let value = target[prop];
+      return (typeof value === 'function') ? value.bind(target) : value; // (*)
     }
-    let value = target[prop];
-    return (typeof value === 'function') ? value.bind(target) : value; // (*)
   },
 *!*
   set(target, prop, val) { // перехватываем запись свойства


### PR DESCRIPTION
Add missing block else in "deleteProperty" example. Other examples always use an if-else block