### PR TITLE
Fixed link for arrow functions article

### DIFF
--- a/1-js/02-first-steps/17-javascript-specials/article.md
+++ b/1-js/02-first-steps/17-javascript-specials/article.md
@@ -272,7 +272,7 @@ switch (age) {
 - У параметров могут быть значения по умолчанию: `function sum(a = 1, b = 2) {...}`.
 - Функции всегда что-нибудь возвращают. Если нет оператора `return`, результатом будет `undefined`.
 
-Подробности: <info:function-basics>, <info:function-expressions-arrows>.
+Подробности: <info:function-basics>, <info:arrow-functions-basics>.
 
 ## Далее мы изучим больше
 


### PR DESCRIPTION
Fixed the link that led to this in the Function section of the "JavaScript Features" page
> Не найдена статья "function-expressions-arrows"