### PR TITLE
Исправил альтернативное решение для задачи "Форматирование относительной даты"

### DIFF
--- a/1-js/05-data-types/11-date/8-format-date-relative/solution.md
+++ b/1-js/05-data-types/11-date/8-format-date-relative/solution.md
@@ -62,6 +62,8 @@ function formatDate(date) {
   year = year.toString().slice(-2);
   month = month < 10 ? '0' + month : month;
   dayOfMonth = dayOfMonth < 10 ? '0' + dayOfMonth : dayOfMonth;
+  hour = hour < 10 ? '0' + hour : hour;
+  minutes = minutes < 10 ? '0' + minutes : minutes;
 
   if (diffSec < 1) {
     return 'прямо сейчас';  


### PR DESCRIPTION
Текущий альтернативный вариант не форматировал часы и минуты в соответствии с условием задачи.
> А именно: "день.месяц.год часы:минуты", всё в виде двух цифр, т.е. 31.12.16 10:00

Поэтому текущий вариант при вызове даты у которых числовые значения часов и минут меньше 10, например, `alert( formatDate(new Date(2019, 10, 17)) );` на выходе дает:
**`17.11.19 0:0`**

Исправленный вариант добавляет форматирование для часов и минут по аналогии с месяцами и днями месяца, чтобы по итогу вызова `alert( formatDate(new Date(2019, 10, 17)) );` на выходе получить:
**`17.11.19 00:00`**