### PR TITLE
fix setCookie (fails when options.expires is not set or is not a Date)

### DIFF
--- a/6-data-storage/01-cookie/article.md
+++ b/6-data-storage/01-cookie/article.md
@@ -311,7 +311,7 @@ function setCookie(name, value, options = {}) {
     ...options
   };
 
-  if (options.expires instanceof Date && options.expires.toUTCString) {
+  if (options.expires instanceof Date) {
     options.expires = options.expires.toUTCString();
   }
 

--- a/6-data-storage/01-cookie/article.md
+++ b/6-data-storage/01-cookie/article.md
@@ -311,7 +311,7 @@ function setCookie(name, value, options = {}) {
     ...options
   };
 
-  if (options.expires.toUTCString) {
+  if (options.expires instanceof Date && options.expires.toUTCString) {
     options.expires = options.expires.toUTCString();
   }
 

--- a/6-data-storage/01-cookie/cookie.js
+++ b/6-data-storage/01-cookie/cookie.js
@@ -13,7 +13,7 @@ function setCookie(name, value, options = {}) {
     ...options
   };
 
-  if (options.expires instanceof Date && options.expires.toUTCString) {
+  if (options.expires instanceof Date) {
     options.expires = options.expires.toUTCString();
   }
 

--- a/6-data-storage/01-cookie/cookie.js
+++ b/6-data-storage/01-cookie/cookie.js
@@ -13,7 +13,7 @@ function setCookie(name, value, options = {}) {
     ...options
   };
 
-  if (options.expires.toUTCString) {
+  if (options.expires instanceof Date && options.expires.toUTCString) {
     options.expires = options.expires.toUTCString();
   }
 


### PR DESCRIPTION
`setCookie` падает, если `options.expires` не задано; в принципе, достаточно проверки `options.expires && options.expires.toUTCString`, но `options.expires instanceof Date && options.expires.toUTCString` удобен тем, что ещё и дружит с TypeScript