### PR TITLE
Fix code example

### DIFF
--- a/1-js/09-classes/03-static-properties-methods/article.md
+++ b/1-js/09-classes/03-static-properties-methods/article.md
@@ -20,7 +20,7 @@ User.staticMethod(); // true
 Это фактически то же самое, что присвоить метод напрямую как свойство функции:
 
 ```js
-class User() { }
+class User { }
 
 User.staticMethod = function() {
   alert(this === User);


### PR DESCRIPTION
Fixed code example syntax mistake in Static properties methods topic.
Done like in [en version](https://github.com/javascript-tutorial/en.javascript.info/blob/master/1-js/09-classes/03-static-properties-methods/article.md)