### PR TITLE
Fixed ###slice

### DIFF
--- a/1-js/05-data-types/05-array-methods/article.md
+++ b/1-js/05-data-types/05-array-methods/article.md
@@ -131,7 +131,7 @@ arr.slice([start], [end])
 ```js run
 let arr = ["t", "e", "s", "t"];
 
-alert( arr.slice(1, 3) ); // e,s (копирует с 1 по 3)
+alert( arr.slice(1, 3) ); // e,s (копирует с 1 до 3)
 
 alert( arr.slice(-2) ); // s,t (копирует с -2 до конца)
 ```


### PR DESCRIPTION
Fixed slice method example
Исправлена опечатка, в примере работы метода slice было указано, что arr.slice(1, 3) - копирует элементы массива с 1 по 3 индекс, на самом деле, копируется  с 1 ДО 3 индекса.