### PR TITLE
Update article.md

### DIFF
--- a/1-js/09-classes/02-class-inheritance/article.md
+++ b/1-js/09-classes/02-class-inheritance/article.md
@@ -82,7 +82,7 @@ rabbit.hide(); // Белый кролик прячется!
 ```
 Теперь код `Rabbit` стал короче, так как используется конструктор класса `Animal` по умолчанию и кролик может использовать метод `run` как и все животные.
 
-На самом деле ключевое слово `extends` добавляет ссылку на `[[Prototype]]` из `Rabbit.prototype` в `Animal.prototype`:
+На самом деле ключевое слово `extends` устанавливает ссылку на `Animal.prototype` в `Rabbit.prototype.[[Prototype]]`:
 
 ![](animal-rabbit-extends.svg)
 


### PR DESCRIPTION
Оригинал:
Internally, extends keyword works using the good old prototype mechanics. It sets Rabbit.prototype.[[Prototype]] to Animal.prototype.

Мне кажется, так будет более понятно.