### PR TITLE
Wrong comment

### DIFF
--- a/2-ui/4-forms-controls/1-form-elements/article.md
+++ b/2-ui/4-forms-controls/1-form-elements/article.md
@@ -221,7 +221,7 @@ input.checked = true; // для чекбоксов и переключателе
     .filter(option => option.selected)
     .map(option => option.value);
 
-  alert(selected); // Блюз,Рок
+  alert(selected); // blues,rock
 </script>
 ```
 


### PR DESCRIPTION
An example that shows how to get the value of the selected options outputs the value from the attribute, not the content of the tag.