### PR TITLE
Small fix in "Intl: интернационализация в JavaScript"

### DIFF
--- a/1-js/99-js-misc/90-intl/article.md
+++ b/1-js/99-js-misc/90-intl/article.md
@@ -221,8 +221,7 @@ let formatter = new Intl.DateTimeFormat([locales, [options]])
     <td></td>
   </tr>
   <tr>
-    <td>second
-    </td>
+    <td><code>second</code></td>
     <td>Секунды</td>
     <td><code>2-digit</code>, <code>numeric</code></td>
     <td></td>


### PR DESCRIPTION
Add missed wrapping in `<code>` tag