### PR TITLE
Обновить ссылку на caniuse

### DIFF
--- a/8-web-components/2-custom-elements/article.md
+++ b/8-web-components/2-custom-elements/article.md
@@ -362,7 +362,7 @@ customElements.define('hello-button', HelloButton, {extends: 'button'});
 ## Ссылки
 
 - HTML Living Standard: <https://html.spec.whatwg.org/#custom-elements>.
-- Совместимость: <https://caniuse.com/#feat=custom-elements>.
+- Совместимость: <https://caniuse.com/#feat=custom-elementsv1>.
 
 ## Итого
 


### PR DESCRIPTION
По текущей ссылке на caniuse открывается страница deprecated версии Custom Elements. Актуальная версия описана здесь: https://caniuse.com/custom-elementsv1
Issue: https://github.com/javascript-tutorial/ru.javascript.info/issues/978