### PR TITLE
Minor fix

### DIFF
--- a/1-js/11-async/08-async-await/article.md
+++ b/1-js/11-async/08-async-await/article.md
@@ -133,7 +133,7 @@ let user = await response.json();
 
 Можно обернуть этот код в анонимную `async`–функцию, тогда всё заработает:
 
-```js run
+```js
 (async () => {
   let response = await fetch('/article/promise-chaining/user.json');
   let user = await response.json();


### PR DESCRIPTION
При запуске анонимной async-функции выдает: <SyntaxError: Unexpected token '}'>, в связи с наличием троеточия, это может запутать и навести на мысль в неправильности использования самой анонимной функции, так называемой IIFE (Immediately Invoked Function Expression). На других версиях запуск отсутствует.