### PR TITLE
Удалены избыточные символы

### DIFF
--- a/9-regular-expressions/11-regexp-groups/04-test-mac/solution.md
+++ b/9-regular-expressions/11-regexp-groups/04-test-mac/solution.md
@@ -9,7 +9,7 @@
 Итог:
 
 ```js run
-let regexp = /^[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}$/i;
+let regexp = /^[0-9a-f]{2}(:[0-9a-f]{2}){5}$/i;
 
 alert( regexp.test('01:32:54:67:89:AB') ); // true
 


### PR DESCRIPTION
Т.к. в регулярном выражении установлен флаг i, то символы 'A-F' являются избыточными. Поэтому они удалены.