### PR TITLE
fix example code for break statement

### DIFF
--- a/1-js/02-first-steps/13-while-for/article.md
+++ b/1-js/02-first-steps/13-while-for/article.md
@@ -217,17 +217,20 @@ let sum = 0;
 
 while (true) {
 
-  let value = +prompt("Введите число", '');
+  let userInput = prompt("Введите число", '');
+  let number = Number(userInput);
 
 *!*
-  if (!value) break; // (*)
+  if (!userInput || isNaN(number)) break; // (*)
 */!*
 
-  sum += value;
+  sum += number;
 
 }
 alert( 'Сумма: ' + sum );
 ```
+
+Для проверки вводимого числа на `NaN` используется функция `isNaN`, которая будет подробнее рассмотрена в главе <info:number>.
 
 Директива `break` в строке `(*)` полностью прекращает выполнение цикла и передаёт управление на строку за его телом, то есть на `alert`.
 


### PR DESCRIPTION
В описании к примеру использования директивы _break_ написано, что код подсчитывает сумму вводимых чисел до тех пор, пока посетитель их вводит.
Исправлено поведение, при котором ввод прекращался, если пользователь вводил число 0.