### PR TITLE
fix value in Intl.NumberFormat table

### DIFF
--- a/1-js/99-js-misc/90-intl/article.md
+++ b/1-js/99-js-misc/90-intl/article.md
@@ -377,7 +377,7 @@ formatter.format(number); // форматирование
     <td><code>maximumSignificantDigits</code></td>
     <td>Максимальное количество значимых цифр</td>
     <td>от <code>minimumSignificantDigits</code> до <code>21</code></td>
-    <td><code>minimumSignificantDigits</code></td>
+    <td><code>21</code></td>
   </tr>
 </table>
 


### PR DESCRIPTION
Fix incorrect default value of maximumSignificantDigits parameter in Intl.NumberFormat table.
Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#parameters