### PR TITLE
remove -moz prefix hint

### DIFF
--- a/20-css-for-js/10-box-sizing/article.md
+++ b/20-css-for-js/10-box-sizing/article.md
@@ -165,7 +165,6 @@ div {
     display: block;
     padding-left: 5px;
 *!*
-    -moz-box-sizing: border-box; /* в Firefox нужен префикс */
     box-sizing: border-box;
     width: 100%;
 */!*


### PR DESCRIPTION
Думаю этот префикс уже можно спокойно удалять из учебника, распространенность версий firefox требующих этого префикса 0.19% на данный момент. https://caniuse.com/css3-boxsizing