### PR TITLE
fix: правка приоритета оператора "??"

### DIFF
--- a/1-js/02-first-steps/12-nullish-coalescing-operator/article.md
+++ b/1-js/02-first-steps/12-nullish-coalescing-operator/article.md
@@ -104,7 +104,7 @@ alert(height ?? 100); // 0
 
 ## Приоритет
 
-Оператор `??` имеет довольно низкий приоритет: `5`, согласно [таблице на MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#Table).
+Оператор `??` имеет довольно низкий приоритет: `4`, согласно [таблице на MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#Table).
 Таким образом, оператор `??` вычисляется до `=` и `?`, но после большинства других операций, таких как `+`, `*`.
 
 Из этого следует, что если нужно выбрать значение при помощи оператора `??` вместе с другими операторами в выражении, следует добавить круглые скобки:


### PR DESCRIPTION
По факту, если перейти по ссылке на таблицу приоритетов MDN, оператор "??" имеет приоритет "4", а не как сейчас указано в статье - "5"