### PR TITLE
update images.yml

### DIFF
--- a/images.yml
+++ b/images.yml
@@ -115,7 +115,7 @@ ifelse_task2.svg:
     text: "Какое"
     position: "center"
   "“official” name of":
-    text: "\"официальное название\""
+    text: "\"официальное\" название"
     position: "center"
   "Иначе": ""
 


### PR DESCRIPTION
Я поменяла название чтобы на svg картинке отображалось `"официальное"` а не  `"официальное название"`. Потому что в тексте выше написано так:

> который будет спрашивать: „Какое «официальное» название JavaScript?“

Я думаю, это должно быть одинаково. Что в тексте что на картинке.


