### PR TITLE
Remove unnecessary 'return'

### DIFF
--- a/1-js/11-async/06-promisify/article.md
+++ b/1-js/11-async/06-promisify/article.md
@@ -53,7 +53,7 @@ function promisify(f) {
     return new Promise((resolve, reject) => {
       function callback(err, result) { // наш специальный колбэк для f
         if (err) {
-          return reject(err);
+          reject(err);
         } else {
           resolve(result);
         }
@@ -84,7 +84,7 @@ function promisify(f, manyArgs = false) {
     return new Promise((resolve, reject) => {
       function *!*callback(err, ...results*/!*) { // наш специальный колбэк для f
         if (err) {
-          return reject(err);
+          reject(err);
         } else {
           // делаем resolve для всех results колбэка, если задано manyArgs
           *!*resolve(manyArgs ? results : results[0]);*/!*


### PR DESCRIPTION
Better to remove 'return' before 'reject' in two example code pieces. This 'return' doesn't make sense.
Also, there is no such 'return' keyword in English version of this article.
This mistake in example code makes difficult to beginners to understand the code, distracts attention, creates questions in comments.