### PR TITLE
Update article.md

### DIFF
--- a/1-js/06-advanced-functions/09-call-apply-decorators/article.md
+++ b/1-js/06-advanced-functions/09-call-apply-decorators/article.md
@@ -256,16 +256,16 @@ let worker = {
 
 function cachingDecorator(func, hash) {
   let cache = new Map();
-  return function() {
+  return function(...args) {
 *!*
-    let key = hash(arguments); // (*)
+    let key = hash(args); // (*)
 */!*
     if (cache.has(key)) {
       return cache.get(key);
     }
 
 *!*
-    let result = func.call(this, ...arguments); // (**)
+    let result = func.call(this, ...args); // (**)
 */!*
 
     cache.set(key, result);
@@ -274,7 +274,7 @@ function cachingDecorator(func, hash) {
 }
 
 function hash(args) {
-  return args[0] + ',' + args[1];
+  return args.toString();
 }
 
 worker.slow = cachingDecorator(worker.slow, hash);


### PR DESCRIPTION
В разделе `Переходим к нескольким аргументам с "func.apply"` после примера кода написано: `Теперь он работает с любым количеством аргументов.`, но `hash` функция обрабатывала только два параметра, а не любое количество аргументов. Тем самым, потенциально, создавая неправильные ключи для кэша функций, принимающих больше двух параметров. Плюс, начиная с ES6 рекомендовано использовать "остаточные параметры" для получения массива аргументов.