### PR TITLE
remove the typo

### DIFF
--- a/2-ui/2-events/01-introduction-browser-events/article.md
+++ b/2-ui/2-events/01-introduction-browser-events/article.md
@@ -235,7 +235,7 @@ element.addEventListener(event, handler, [options]);
 Для удаления обработчика следует использовать `removeEventListener`:
 
 ```js
-element.removeEventListener(event, handler[, options]);
+element.removeEventListener(event, handler, [options]);
 ```
 
 ````warn header="Удаление требует именно ту же функцию"


### PR DESCRIPTION
element.removeEventListener(event, handler [, options]); change
element.removeEventListener(event, handler, [options]);