### PR TITLE
Опечатка в первом примере раздела "Регулярные выражения / Скобочные группы" 

### DIFF
--- a/9-regular-expressions/11-regexp-groups/article.md
+++ b/9-regular-expressions/11-regexp-groups/article.md
@@ -18,7 +18,7 @@
 Скобки группируют символы вместе. Так что `pattern:(go)+` означает `match:go`, `match:gogo`, `match:gogogo` и т.п.
 
 ```js run
-alert( 'Gogogo now!'.match(/(go)+/i) ); // "Gogogo"
+alert( 'Gogogo now!'.match(/(go)+/ig) ); // "Gogogo"
 ```
 
 ### Пример: домен


### PR DESCRIPTION
пропущен флаг `g`, без которого alert выдаёт массив "Gogogo,go", вместо обещанного "Gogogo"