### PR TITLE
Update round fraction example

### DIFF
--- a/1-js/05-data-types/02-number/article.md
+++ b/1-js/05-data-types/02-number/article.md
@@ -151,7 +151,7 @@ alert( num.toString(2) );   // 11111111
     ```js run
     let num = 1.23456;
 
-    alert( Math.floor(num * 100) / 100 ); // 1.23456 -> 123.456 -> 123 -> 1.23
+    alert( Math.round(num * 100) / 100 ); // 1.23456 -> 123.456 -> 123 -> 1.23
     ```
 
 2. Метод [toFixed(n)](https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed) округляет число до `n` знаков после запятой и возвращает строковое представление результата.


### PR DESCRIPTION
In the particular example with multiplying and dividing by 100 there is no mistake. However using `Math.round` instead of `Math.floor` would be better. If it was a number `1.23567`, the rounded result would be `1.24`. But with the current `Math.floor` we still get `1.23` which is incorrect.