### PR TITLE
fixed map-set article

### DIFF
--- a/1-js/05-data-types/07-map-set/article.md
+++ b/1-js/05-data-types/07-map-set/article.md
@@ -294,8 +294,8 @@ set.forEach((value, valueAgain, set) => {
 
 `Set` имеет те же встроенные методы, что и `Map`:
 
-- [`set.keys()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/keys) -- возвращает перебираемый объект для значений,
-- [`set.values()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/values) -- то же самое, что и `set.keys()`, присутствует для обратной совместимости с `Map`,
+- [`set.values()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/values) -- возвращает перебираемый объект для значений,
+- [`set.keys()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/keys) -- то же самое, что и `set.values()`, присутствует для обратной совместимости с `Map`,
 - [`set.entries()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/entries) -- возвращает перебираемый объект для пар вида `[значение, значение]`, присутствует для обратной совместимости с `Map`.
 
 ## Итого


### PR DESCRIPTION
Думаю писать, что `set.values()` добавлен для обратной совместимости немного некорректно, ибо коллекция `Set` изначально имеет только значения без ключей. Так что скорее `set.keys()` добавлен для обратной совместимости.