### PR TITLE
Fix Promise.allSettled polyfill

### DIFF
--- a/1-js/11-async/05-promise-api/article.md
+++ b/1-js/11-async/05-promise-api/article.md
@@ -186,7 +186,7 @@ Promise.allSettled(urls.map(url => fetch(url)))
 ```js
 if(!Promise.allSettled) {
   Promise.allSettled = function(promises) {
-    return Promise.all(promises.map(p => Promise.resolve(p).then(value => ({
+    return Promise.all(Array.from(promises).map(p => Promise.resolve(p).then(value => ({
       status: 'fulfilled',
       value: value
     }), error => ({


### PR DESCRIPTION
<!-- 😉 Спасибо за ваш PR! Добавление информации в полях ниже поможет нам намного быстрее его рассмотреть. -->

## Описание

функция Promise.allSettled принимает итерируемый объект (не обязательно массив) как параметр, но в теле функции в учебнике используется метод map на этом итерируемом объекте, что даст ошибку, если там не массив. Поэтому логичнее обернуть сначала этот объект в Array.from(), и затем использовать метод массива map



