### PR TITLE
WebSocket: Поправил Backend-пример

### DIFF
--- a/5-network/11-websocket/article.md
+++ b/5-network/11-websocket/article.md
@@ -327,12 +327,13 @@ socket.onmessage = function(event) {
 4. Когда подключение закрыто: `clients.delete(socket)`.
 
 ```js
-const ws = new require('ws');
+const http = require('http');
+const ws = require('ws');
 const wss = new ws.Server({noServer: true});
 
 const clients = new Set();
 
-http.createServer((req, res) => {
+const server = http.createServer((req, res) => {
   // в реальном проекте здесь может также быть код для обработки отличных от websoсket-запросов
   // здесь мы работаем с каждым запросом как с веб-сокетом
   wss.handleUpgrade(req, req.socket, Buffer.alloc(0), onSocketConnect);
@@ -353,6 +354,8 @@ function onSocketConnect(ws) {
     clients.delete(ws);
   });
 }
+
+server.listen(80);
 ```
 
 Вот рабочий пример:


### PR DESCRIPTION
1. Добавил импорт модуля `http` (без него - ошибка)
![image](https://github.com/user-attachments/assets/d35cfbaa-54ec-4566-8f82-e87355a3dcef)
2. Добавил `server.listen(80)` (без него - скрипт сразу завершался)
3. `WebSocket.prototype` не имеет поля `Server`, так что `new (new WebSocket).Server(...)` - некорректно. Внёс правку: `new WebSocket.Server(...)`
> VSC дело говорит (до/после):
> ![image](https://github.com/user-attachments/assets/75baaba2-f7ca-4d73-9c2e-70def3688020)
> ![image](https://github.com/user-attachments/assets/6bd271a2-7903-4e4c-aa3c-67ca9d918395)
