### PR TITLE
Исправление неточности в синтаксисе метода 5.5

### DIFF
--- a/1-js/05-data-types/05-array-methods/article.md
+++ b/1-js/05-data-types/05-array-methods/article.md
@@ -41,7 +41,7 @@ alert( arr.length ); // 3
 Синтаксис:
 
 ```js
-arr.splice(start[, deleteCount, elem1, ..., elemN])
+arr.splice(start, [deleteCount, elem1, ..., elemN])
 ```
 
 Он изменяет `arr` начиная с индекса `start`: удаляет `deleteCount` элементов и затем вставляет `elem1, ..., elemN` на их место. Возвращает массив из удалённых элементов.


### PR DESCRIPTION
В синтаксисе метода массивов splice допущена ошибка.  `,` и `[` нужно поменять местами
<img width="485" alt="image" src="https://github.com/user-attachments/assets/b882c07f-9579-41be-8568-b76e8d0e2be3">

