### PR TITLE
Исправил значение по умолчанию опции minimumIntegerDigits

### DIFF
--- a/1-js/99-js-misc/90-intl/article.md
+++ b/1-js/99-js-misc/90-intl/article.md
@@ -353,7 +353,7 @@ formatter.format(number); // форматирование
     <td>Минимальное количество цифр целой части</td>
     <td>от `1` до `21`
     </td>
-    <td><code>21</code></td>
+    <td><code>1</code></td>
   </tr>
   <tr>
     <td><code>minimumFractionDigits</code> </td>


### PR DESCRIPTION
## Описание

Значение по умолчанию опции minimumIntegerDigits в конструкторе Intl.NumberFormat — это 1, а не 21 как в тексте

## Ссылки

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#minimumintegerdigits