### PR TITLE
Исправление ошибки в функции карирования

### DIFF
--- a/1-js/99-js-misc/03-currying-partials/article.md
+++ b/1-js/99-js-misc/03-currying-partials/article.md
@@ -122,7 +122,7 @@ function curry(func) {
     if (args.length >= func.length) {
       return func.apply(this, args);
     } else {
-      return function(...args2) {
+      return (...args2) => {
         return curried.apply(this, args.concat(args2));
       }
     }
@@ -155,9 +155,10 @@ function curried(...args) {
   if (args.length >= func.length) { // (1)
     return func.apply(this, args);
   } else {
-    return function pass(...args2) { // (2)
+    const pass = (...args2) => { // (2)
       return curried.apply(this, args.concat(args2));
     }
+    return pass;
   }
 };
 ```


### PR DESCRIPTION
## Описание

В примере учебника функции карирования явно добавлен метод apply, указывающий, что мы должны помнить о контексте. Но пример не учел, что возвращаемую рекурсивно функцию curried так же оборачивают в анонимную функцию, у которой свой контекст this, из-за чего происходит потеря изначального контекста и пример работает не правильно.
Замена анонимной функции на стрелочную решает проблему, так как стрелочная функция не имеет своего this, и берет его у своего родителя.

Вот пример где ошибку легко воспроизвести

```js
function curry(func) {

  return function curried(...args) {
    if (args.length >= func.length) {
      return func.apply(this, args);
    } else {
      return function(...args2) {
        return curried.apply(this, args.concat(args2));
      }
    }
  };

}

function testFn(biba, boba) {
  return this.prefix + biba + ', ' + boba;
}

const obj = {
  prefix: "Mokss: ",
  test: curry(testFn)
};

console.log(obj.test("Biba")("Boba")); // undefinedBiba, Boba
```

Пример с фиксом, где код работает ожидаемо

```js
function curry(func) {

  return function curried(...args) {
    if (args.length >= func.length) {
      return func.apply(this, args);
    } else {
      return (...args2) => {
        return curried.apply(this, args.concat(args2));
      }
    }
  };

}

function testFn(biba, boba) {
  return this.prefix + biba + ', ' + boba;
}

const obj = {
  prefix: "Mokss: ",
  test: curry(testFn)
};

console.log(obj.test("Biba")("Boba")); // Mokss: Biba, Boba
```

