### PR TITLE
Исправление неточности в статье "IndexedDB"

### DIFF
--- a/6-data-storage/03-indexeddb/article.md
+++ b/6-data-storage/03-indexeddb/article.md
@@ -268,7 +268,7 @@ db.deleteObjectStore('books')
 
 Для начала транзакции:
 
-```js run
+```js
 db.transaction(store[, type]);
 ```
 


### PR DESCRIPTION
## Описание

Удалено `run` из примера кода `db.transaction(store[, type]);`, так как оно вызывало синтаксическую ошибку при запуске: `SyntaxError: Unexpected token ','`