### PR TITLE
fix: correct definition of spread syntax in generators article.md ru

### DIFF
--- a/1-js/12-generators-iterators/1-generators/article.md
+++ b/1-js/12-generators-iterators/1-generators/article.md
@@ -155,7 +155,7 @@ let sequence = [0, ...generateSequence()];
 alert(sequence); // 0, 1, 2, 3
 ```
 
-В коде выше `...generateSequence()` превращает перебираемый объект-генератор в массив элементов (подробнее ознакомиться с оператором расширения можно в главе [](info:rest-parameters-spread-operator#spread-operator))
+В коде выше `...generateSequence()` «расширяет» перебираемый объект-генератор в список значений (подробнее ознакомиться с оператором расширения можно в главе [](info:rest-parameters-spread-operator#spread-operator))
 
 ## Использование генераторов для перебираемых объектов
 

--- a/1-js/12-generators-iterators/1-generators/article.md
+++ b/1-js/12-generators-iterators/1-generators/article.md
@@ -155,7 +155,7 @@ let sequence = [0, ...generateSequence()];
 alert(sequence); // 0, 1, 2, 3
 ```
 
-В коде выше `...generateSequence()` «расширяет» перебираемый объект-генератор в список значений (подробнее ознакомиться с оператором расширения можно в главе [](info:rest-parameters-spread-operator#spread-operator))
+В коде выше `...generateSequence()` "расширяет" перебираемый объект-генератор в список значений (подробнее ознакомиться с оператором расширения можно в главе [](info:rest-parameters-spread-operator#spread-operator))
 
 ## Использование генераторов для перебираемых объектов
 


### PR DESCRIPTION
### Generators
Spread syntax doesn't turn the iterable object into an array of elements,
but in this article example, when used in a literal array declaration,
it adds the expanded list of generator values ​​to that array✅