### PR TITLE
Change width of digit element from 0.5em to 0.6em

### DIFF
--- a/7-animation/2-css-animations/digits.view/style.css
+++ b/7-animation/2-css-animations/digits.view/style.css
@@ -1,5 +1,5 @@
 #digit {
-  width: .5em;
+  width: .6em;
   overflow: hidden;
   font: 32px monospace;
   cursor: pointer;


### PR DESCRIPTION
## Описание

В примере "digits" из раздела «CSS-анимации» в файле style.css увеличена ширина контейнера #digit с .5em до .6em, чтобы числа строки корректно помещались в рамку. Изменение влияет только на верстку/визуальное отображение.

До:
<img width="855" height="198" alt="image" src="https://github.com/user-attachments/assets/49f94b74-3ffc-4c98-86f8-1bc14a7eab1a" />

После:
<img width="855" height="198" alt="image" src="https://github.com/user-attachments/assets/8c7431a7-7d95-44b7-bb01-016aca62a699" />