### PR TITLE
Change width of digit element from 0.5em to 0.6em

### DIFF
--- a/7-animation/2-css-animations/digits-negative-delay.view/style.css
+++ b/7-animation/2-css-animations/digits-negative-delay.view/style.css
@@ -1,5 +1,5 @@
 #digit {
-  width: .5em;
+  width: .6em;
   overflow: hidden;
   font: 32px monospace;
   cursor: pointer;


### PR DESCRIPTION
## Описание

В примере "digits-negative-delay" из раздела «CSS-анимации» в файле style.css увеличена ширина контейнера #digit с .5em до .6em, чтобы числа строки корректно помещались в рамку. Изменение влияет только на верстку/визуальное отображение.


