### PR TITLE
Switch lesson first task typo

### DIFF
--- a/1-js/02-first-steps/14-switch/1-rewrite-switch-if-else/solution.md
+++ b/1-js/02-first-steps/14-switch/1-rewrite-switch-if-else/solution.md
@@ -3,18 +3,18 @@
 Впрочем, для таких строк, подойдёт и обычное сравнение `'=='`.
 
 ```js no-beautify
-if(browser == 'Edge') {
+if(browser === 'Edge') {
   alert("You've got the Edge!");
-} else if (browser == 'Chrome'
- || browser == 'Firefox'
- || browser == 'Safari'
- || browser == 'Opera') {
+} else if (browser === 'Chrome'
+ || browser === 'Firefox'
+ || browser === 'Safari'
+ || browser === 'Opera') {
   alert( 'Okay we support these browsers too' );
 } else {
   alert( 'We hope that this page looks ok!' );
 }
 ```
 
-Обратите внимание: конструкция `browser == 'Chrome' || browser == 'Firefox' ...` разбита на несколько строк для лучшей читаемости.
+Обратите внимание: конструкция `browser === 'Chrome' || browser === 'Firefox' ...` разбита на несколько строк для лучшей читаемости.
 
 Но всё равно запись через `switch` нагляднее.


### PR DESCRIPTION
Replaced '==' with '==='

<!-- 😉 Спасибо за ваш PR! Добавление информации в полях ниже поможет нам намного быстрее его рассмотреть. -->

## Описание

Исправил опечатку в первой задаче в уроке switch заменил '==' на '==='
<!-- 📃 Кратко опишите ваши правки. Почему они должны быть внесены в учебник? -->

## Ссылки

<!-- 🔗 Добавьте ссылки на материалы, которые могут подтвердить корректность ваших правок. Например: -->
<!-- «ECMAScript Language Specification», «MDN Web Docs», «caniuse.com», «W3C standards» и т.п. -->

<!-- ✒ Если ваш PR вносит пунктуационные, орфографические или стилистические правки в текст, вы можете... -->
<!-- …добавить ссылки на материалы из «gramota.ru». Возможны и другие подобные источники. -->

<!-- 💡 Если корректность правок, на ваш взгляд, достаточно очевидна и не требует подтверждающих материалов,… -->
<!-- ...вы можете оставить это поле пустым. -->

## Связанные Issue

<!-- 🔨 Если этот PR может закрыть какую-либо Issue (или сразу несколько), добавьте "Resolves #номер_issue" -->
