### PR TITLE
Исправить инвертированную семантику флага open у IDBKeyRange

### DIFF
--- a/6-data-storage/03-indexeddb/article.md
+++ b/6-data-storage/03-indexeddb/article.md
@@ -491,9 +491,9 @@ request.onerror = function(event) {
 
 Диапазоны создаются с помощью следующих вызовов:
 
-- `IDBKeyRange.lowerBound(lower, [open])` означает: `>lower` (или `≥lower`, если `open` это true)
-- `IDBKeyRange.upperBound(upper, [open])` означает: `<upper` (или `≤upper`, если `open` это true)
-- `IDBKeyRange.bound(lower, upper, [lowerOpen], [upperOpen])` означает: между `lower` и `upper`, включительно, если соответствующий `open` равен `true`.
+- `IDBKeyRange.lowerBound(lower, [open])` означает: `≥lower` (или `>lower`, если `open` это true)
+- `IDBKeyRange.upperBound(upper, [open])` означает: `≤upper` (или `<upper`, если `open` это true)
+- `IDBKeyRange.bound(lower, upper, [lowerOpen], [upperOpen])` означает: между `lower` и `upper`. Если соответствующий `open` равен `true`, то граница не включается в диапазон.
 - `IDBKeyRange.only(key)` -- диапазон, который состоит только из одного ключа `key`, редко используется.
 
 Очень скоро мы увидим практические примеры их использования.


### PR DESCRIPTION
Fixes #2092

В описании диапазонов `IDBKeyRange` семантика флага `open` была инвертирована: было написано, что `open: true` **включает** границу, хотя на самом деле — исключает.

Исправлено по [английской версии учебника](https://github.com/javascript-tutorial/en.javascript.info/blob/master/6-data-storage/03-indexeddb/article.md) и [спецификации IndexedDB](https://www.w3.org/TR/IndexedDB/#keyrange):

- `lowerBound(lower, [open])` → `≥lower` (или `>lower`, если `open` это true)
- `upperBound(upper, [open])` → `≤upper` (или `<upper`, если `open` это true)
- `bound(...)` → границы не включаются, если соответствующий `open` равен `true`

Примеры кода ниже по статье (`// получить книги с id < 'html'` для `upperBound('html', true)`) уже соответствовали правильной семантике — теперь определения с ними согласованы.