### PR TITLE
Преобразовывать ввод prompt в числа унарным плюсом (задача pow)

### DIFF
--- a/1-js/02-first-steps/15-function-basics/4-pow/solution.md
+++ b/1-js/02-first-steps/15-function-basics/4-pow/solution.md
@@ -10,8 +10,8 @@ function pow(x, n) {
   return result;
 }
 
-let x = prompt("x?", '');
-let n = prompt("n?", '');
+let x = +prompt("x?", '');
+let n = +prompt("n?", '');
 
 if (n >= 1 && n % 1 == 0) {
   alert( pow(x, n) );
@@ -19,3 +19,4 @@ if (n >= 1 && n % 1 == 0) {
   alert(`Степень ${n} не поддерживается, используйте натуральное число`);
 }
 ```
+


### PR DESCRIPTION
Порт свежего апстрим-фикса из английской версии: [en#3977](https://github.com/javascript-tutorial/en.javascript.info/pull/3977) (коммит [`a1973755`](https://github.com/javascript-tutorial/en.javascript.info/commit/a1973755)).

В решении задачи «Возведение в степень pow(x, n)» значения из `prompt` использовались как строки. Добавлен унарный плюс, чтобы `x` и `n` сразу были числами — как теперь в английской версии:

```js
let x = +prompt("x?", '');
let n = +prompt("n?", '');
```

Остальной текст решения не менялся.